### PR TITLE
Changed line length in .jshintrc to 120 characters & set esnext to tr…

### DIFF
--- a/linters/README.md
+++ b/linters/README.md
@@ -1,7 +1,3 @@
-## `.eslintrc`
+## `.jshintrc`
 
-Our `.eslintrc` requires the following NPM packages packages:
-
-- `eslint`
-- `babel-eslint`
-- `eslint-plugin-react`
+Use the `.jshintrc` and `.jscsrc` in the linters/ folder for linting preferences.

--- a/linters/jscsrc
+++ b/linters/jscsrc
@@ -1,3 +1,4 @@
 {
-  "preset": "airbnb"
+  "preset": "airbnb",
+  "esnext": true
 }

--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -35,7 +35,7 @@
   "latedef": true,
 
   // Enforce line length to 80 characters
-  "maxlen": 80,
+  "maxlen": 120,
 
   // Require capitalized names for constructor functions.
   "newcap": true,


### PR DESCRIPTION
tiny pr:

- .jshintrc maxlen set to 120,
- .jscs esnext set to true (for all es6 reserved words)
- Updated readme to include jshint and jscsrc descriptions & update.